### PR TITLE
add tests for file service

### DIFF
--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -34,6 +34,7 @@ service File {
 
 message CreateRequest {
   string path  = 1;
+  string content = 2;
 }
 
 message OpenRequest {
@@ -92,5 +93,14 @@ enum FileErr {
     NoError = 0; // mandatory
     DispatchError = 1; //mandatory
     UnmarshalError = 2; // mandatory
+
+    // invalid path means that the given path name is a not a valid identifier.  Identifiers should be 
+    // shortest path name equivalent to path by purely lexical processingand. Specifically, it should 
+    // start with "/parigot/app/", also, any use of '.', '..', '//' (duplicate /, like //, ///, etc...) 
+    // in the path is not allowed.
+    InvalidPathError = 3;
+
+    PermissionError = 4;
+    NotExistError = 5;
 
 }

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -19,7 +19,11 @@ import "protosupport/v1/protosupport.proto";
 
 service File {
   rpc Open(OpenRequest) returns (OpenResponse);
+
+  // Create creates or truncates the named file in the path. If the file already exists, 
+  // it is truncated. If the file does not exist, it is created with mode 0666 (before umask).
   rpc Create(CreateRequest) returns (CreateResponse);
+
   rpc Close(CloseRequest) returns (CloseResponse);
 
   // Load does NOT check that the file(s) referred to are reasonable in length, do not contain

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -93,14 +93,10 @@ enum FileErr {
     NoError = 0; // mandatory
     DispatchError = 1; //mandatory
     UnmarshalError = 2; // mandatory
-
     // invalid path means that the given path name is a not a valid identifier.  Identifiers should be 
     // shortest path name equivalent to path by purely lexical processingand. Specifically, it should 
-    // start with "/parigot/app/", also, any use of '.', '..', '//' (duplicate /, like //, ///, etc...) 
-    // in the path is not allowed.
+    // start with "/parigot/app/", also, any use of '.' or '..' in the path is not allowed.
     InvalidPathError = 3;
-
-    PermissionError = 4;
+    AlreadyInUseError = 4;
     NotExistError = 5;
-
 }

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -21,7 +21,7 @@ service File {
   rpc Open(OpenRequest) returns (OpenResponse);
 
   // Create creates or truncates the named file in the path. If the file already exists, 
-  // it is truncated. If the file does not exist, it is created with mode 0666 (before umask).
+  // it is truncated. If the file does not exist, it is created.
   rpc Create(CreateRequest) returns (CreateResponse);
 
   rpc Close(CloseRequest) returns (CloseResponse);

--- a/apiplugin/file/file_test.go
+++ b/apiplugin/file/file_test.go
@@ -44,10 +44,6 @@ func TestOpenClose(t *testing.T) {
 	// also try closing a file twice, there should be an error in the second time
 	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
 	testFileClose(t, svc, fid, "close a file that does not exist", true, int32(file.FileErr_NotExistError))
-
-	// when expecting an error, for now you'll have to use
-	// the raw numbers from the list of errors
-	// apiwasm/file/fileerr.go
 }
 
 func TestCreateClose(t *testing.T) {
@@ -88,7 +84,7 @@ func TestCreateClose(t *testing.T) {
 
 	// close a file twice, the seconde time there should have an error
 	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
-	testFileClose(t, svc, fid, "close a file", true, int32(file.FileErr_NotExistError))
+	testFileClose(t, svc, fid, "close a closed file", true, int32(file.FileErr_NotExistError))
 
 	// create a file with the same path
 	fid2 = creatAGoodFile(t, svc)
@@ -159,7 +155,6 @@ func testFileClose(t *testing.T, svc *fileSvcImpl, fid file.FileId, msg string,
 	if !fid.Equal(candidate) {
 		log.Fatalf("created and closed file id don't match")
 	}
-	return
 }
 
 func testFileOpen(t *testing.T, svc *fileSvcImpl, fpath string, msg string,

--- a/apiplugin/file/file_test.go
+++ b/apiplugin/file/file_test.go
@@ -14,15 +14,36 @@ import (
 // real impleentations directly.
 
 const fileContent = "Hello! Parigot!"
+const filePath = "/parigot/app/file.go"
 
 func TestOpenClose(t *testing.T) {
-	// try open a file with a badly formed path name, make sure it fails
-	// see filepath.Clean()
+	svc := newFileSvc((context.Background()))
+	creatAGoodFile(t, svc)
+
+	// try opening a file does not exist
+	badFid := testFileOpen(t, svc, "/parigot/app/badfile.txt", "path doesn't exist",
+		true, int32(file.FileErr_NotExistError))
+	if !badFid.IsEmptyValue() {
+		t.Errorf("trying to open a file which does not exist")
+	}
+	// try open a file with a badly formed path name
+	badFid = testFileOpen(t, svc, "badfile.txt", "bad path name",
+		true, int32(file.FileErr_InvalidPathError))
+	if !badFid.IsEmptyValue() {
+		t.Errorf("accidentally opened a file with the a bad path name")
+	}
 
 	// try opening and closing a file
+	fid := testFileOpen(t, svc, filePath, "open a file", false, int32(file.FileErr_NoError))
+	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
 
 	// also try opening a file twice, for now should be an error
-	// also try closing a file twice
+	creatAGoodFile(t, svc)
+	fid = testFileOpen(t, svc, filePath, "open a file", false, int32(file.FileErr_NoError))
+	testFileOpen(t, svc, filePath, "open a open file", true, int32(file.FileErr_PermissionError))
+	// also try closing a file twice, there should be an error in the second time
+	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
+	testFileClose(t, svc, fid, "close a file that does not exist", true, int32(file.FileErr_NotExistError))
 
 	// when expecting an error, for now you'll have to use
 	// the raw numbers from the list of errors
@@ -33,13 +54,29 @@ func TestCreateClose(t *testing.T) {
 	svc := newFileSvc((context.Background()))
 
 	// create a file with duplicate "/" in the path name
-	testFileCreate(t, svc, "/parigot/app///file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	badFid := testFileCreate(t, svc, "/parigot/app///file.go", fileContent,
+		"bad path name", true, int32(file.FileErr_InvalidPathError))
+	if !badFid.IsZeroValue() {
+		t.Errorf("accidentally created a file with the a bad path name")
+	}
 	// create a file with . in the path name
-	testFileCreate(t, svc, "/parigot/app/./file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	badFid = testFileCreate(t, svc, "/parigot/app/./file.go", fileContent,
+		"bad path name", true, int32(file.FileErr_InvalidPathError))
+	if !badFid.IsZeroValue() {
+		t.Errorf("accidentally created a file with the a bad path name")
+	}
 	// create a file with .. in the path name
-	testFileCreate(t, svc, "/parigot/app/../file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	badFid = testFileCreate(t, svc, "/parigot/app/../file.go", fileContent,
+		"bad path name", true, int32(file.FileErr_InvalidPathError))
+	if !badFid.IsZeroValue() {
+		t.Errorf("accidentally created a file with the a bad path name")
+	}
 	// create a file without prefix '/parigot/app/'
-	testFileCreate(t, svc, "file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	badFid = testFileCreate(t, svc, "dir/file.go", fileContent, "bad path name",
+		true, int32(file.FileErr_InvalidPathError))
+	if !badFid.IsZeroValue() {
+		t.Errorf("accidentally created a file with the a bad path name")
+	}
 
 	// create a file with a good name
 	fid := creatAGoodFile(t, svc)
@@ -60,24 +97,24 @@ func TestCreateClose(t *testing.T) {
 	}
 }
 
-func testFileCreate(t *testing.T, svc *fileSvcImpl, path string, content string, msg string,
-	expectedErr bool, expectedErrCode int32) file.FileId {
+func testFileCreate(t *testing.T, svc *fileSvcImpl, fpath string, content string, msg string,
+	errExpected bool, expectedErrCode int32) file.FileId {
 
 	ctx := pcontext.DevNullContext(context.Background())
 	t.Helper()
 
-	openReq := &file.CreateRequest{
-		Path:    path,
+	req := &file.CreateRequest{
+		Path:    fpath,
 		Content: content,
 	}
-	openResp := &file.CreateResponse{}
-	errCode := svc.create(ctx, openReq, openResp)
-	if expectedErr {
+	resp := &file.CreateResponse{}
+	errCode := svc.create(ctx, req, resp)
+	if errExpected {
 		if errCode == int32(file.FileErr_NoError) {
-			log.Fatalf("expected error from creating a file: %s :%d", msg, errCode)
+			log.Fatalf("expected error in creating a file: %s :%d", msg, errCode)
 		}
 		if expectedErrCode != errCode {
-			log.Fatalf("wrong error code from creating a file: %s, expected %d but got %d",
+			log.Fatalf("wrong error code in creating a file: %s, expected %d but got %d",
 				msg, expectedErrCode, errCode)
 		}
 		return file.FileIdZeroValue()
@@ -85,28 +122,30 @@ func testFileCreate(t *testing.T, svc *fileSvcImpl, path string, content string,
 
 	// no error expected case
 	if errCode != int32(file.FileErr_NoError) {
-		log.Fatalf("unexpected error from creating a file: %s :%d", msg, errCode)
+		log.Fatalf("unexpected error in creating a file: %s :%d", msg, errCode)
 	}
 
-	return file.UnmarshalFileId(openResp.GetId())
+	return file.UnmarshalFileId(resp.GetId())
 }
 
 func testFileClose(t *testing.T, svc *fileSvcImpl, fid file.FileId, msg string,
-	expectedErr bool, expectedErrCode int32) {
+	errExpected bool, expectedErrCode int32) {
 
 	ctx := pcontext.DevNullContext(context.Background())
 	t.Helper()
 
-	req := &file.CloseRequest{}
+	req := &file.CloseRequest{
+		Id: fid.Marshal(),
+	}
 	resp := &file.CloseResponse{}
-	req.Id = fid.Marshal()
+
 	errCode := svc.close(ctx, req, resp)
-	if expectedErr {
+	if errExpected {
 		if errCode == int32(file.FileErr_NoError) {
-			log.Fatalf("expected error from closing a file (%s): %s: %d", fid, msg, errCode)
+			log.Fatalf("expected error in closing a file (%s): %s: %d", fid, msg, errCode)
 		}
 		if errCode != expectedErrCode {
-			log.Fatalf("wrong error code from closing a file (%s): %s expected %d but got %d",
+			log.Fatalf("wrong error code in closing a file (%s): %s expected %d but got %d",
 				fid, msg, expectedErrCode, errCode)
 		}
 		return
@@ -114,7 +153,7 @@ func testFileClose(t *testing.T, svc *fileSvcImpl, fid file.FileId, msg string,
 
 	// no error expected case
 	if errCode != int32(file.FileErr_NoError) {
-		log.Fatalf("unexpected error from closing a file (%s): %s :%d", fid, msg, errCode)
+		log.Fatalf("unexpected error in closing a file (%s): %s :%d", fid, msg, errCode)
 	}
 	candidate := file.UnmarshalFileId(resp.GetId())
 	if !fid.Equal(candidate) {
@@ -123,7 +162,37 @@ func testFileClose(t *testing.T, svc *fileSvcImpl, fid file.FileId, msg string,
 	return
 }
 
+func testFileOpen(t *testing.T, svc *fileSvcImpl, fpath string, msg string,
+	errExpected bool, expectedErrCode int32) file.FileId {
+
+	ctx := pcontext.DevNullContext(context.Background())
+	t.Helper()
+
+	req := &file.OpenRequest{
+		Path: fpath,
+	}
+	resp := &file.OpenResponse{}
+	errCode := svc.open(ctx, req, resp)
+	if errExpected {
+		if errCode == int32(file.FileErr_NoError) {
+			log.Fatalf("expected error in opening a file: %s :%d", msg, errCode)
+		}
+		if errCode != expectedErrCode {
+			log.Fatalf("wrong error code in opening a file: %s, expected %d but got %d",
+				msg, expectedErrCode, errCode)
+		}
+		return file.FileIdEmptyValue()
+	}
+
+	// no error expected case
+	if errCode != int32(file.FileErr_NoError) {
+		log.Fatalf("unexpected error in opening a file: %s :%d", msg, errCode)
+	}
+
+	return file.UnmarshalFileId(resp.GetId())
+}
+
 func creatAGoodFile(t *testing.T, svc *fileSvcImpl) file.FileId {
-	return testFileCreate(t, svc, "/parigot/app/file.go", fileContent, "good path name",
+	return testFileCreate(t, svc, filePath, fileContent, "good path name",
 		false, int32(file.FileErr_NoError))
 }

--- a/apiplugin/file/file_test.go
+++ b/apiplugin/file/file_test.go
@@ -1,12 +1,27 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	pcontext "github.com/iansmith/parigot/context"
+	"github.com/iansmith/parigot/g/file/v1"
+	filemsg "github.com/iansmith/parigot/g/msg/file/v1"
+)
 
 // if you look at the tests in queue_test you'll see that
 // the tests ignore the wrapper functions and use the
 // real impleentations directly.
 
 func TestOpenClose(t *testing.T) {
+	svc := newFileSvc((context.Background()))
+
+	// Needs to be rewritten
+	testFileCreate(t, svc, "/app/", "good path name", false, 0)
+
+	// que := filemsg.OpenRequest{
+	// 	Path: "$$$$.###",
+	// }
 
 	// try open a file with a badly formed path name, make sure it fails
 	// see filepath.Clean()
@@ -19,8 +34,39 @@ func TestOpenClose(t *testing.T) {
 	// when expecting an error, for now you'll have to use
 	// the raw numbers from the list of errors
 	// apiwasm/file/fileerr.go
+
+	///////////////////////////////////////
+	// new a file service
 }
 
 func TestCreateClose(t *testing.T) {
 
+}
+
+func testFileCreate(t *testing.T, svc *fileSvcImpl, path string, msg string, errorExpected bool, expectedCode uint16) file.FileId {
+	ctx := pcontext.DevNullContext(context.Background())
+	t.Helper()
+
+	create := &filemsg.CreateRequest{
+		Path: path,
+	}
+	resp := &filemsg.CreateResponse{}
+	err := file.NewFileErrIdFromRaw(svc.create(ctx, create, resp))
+	if errorExpected {
+		if !err.IsError() {
+			t.Errorf("expected error: %s :%s", msg, err.Short())
+		}
+		if file.FileErrIdCode(expectedCode) != err.ErrorCode() {
+			t.Errorf("wrong code : %s, expected %d but got %d", msg, expectedCode, err.ErrorCode())
+		}
+		return file.ZeroValueFileId()
+	}
+
+	// no error expected case
+	if err.IsError() {
+		t.Errorf("unexpected error: %s :%s", msg, err.Short())
+		return file.ZeroValueFileId()
+	}
+
+	return file.MustUnmarshalFileId(resp.GetId())
 }

--- a/apiplugin/file/file_test.go
+++ b/apiplugin/file/file_test.go
@@ -2,27 +2,20 @@ package main
 
 import (
 	"context"
+	"log"
 	"testing"
 
 	pcontext "github.com/iansmith/parigot/context"
 	"github.com/iansmith/parigot/g/file/v1"
-	filemsg "github.com/iansmith/parigot/g/msg/file/v1"
 )
 
 // if you look at the tests in queue_test you'll see that
 // the tests ignore the wrapper functions and use the
 // real impleentations directly.
 
+const fileContent = "Hello! Parigot!"
+
 func TestOpenClose(t *testing.T) {
-	svc := newFileSvc((context.Background()))
-
-	// Needs to be rewritten
-	testFileCreate(t, svc, "/app/", "good path name", false, 0)
-
-	// que := filemsg.OpenRequest{
-	// 	Path: "$$$$.###",
-	// }
-
 	// try open a file with a badly formed path name, make sure it fails
 	// see filepath.Clean()
 
@@ -34,39 +27,103 @@ func TestOpenClose(t *testing.T) {
 	// when expecting an error, for now you'll have to use
 	// the raw numbers from the list of errors
 	// apiwasm/file/fileerr.go
-
-	///////////////////////////////////////
-	// new a file service
 }
 
 func TestCreateClose(t *testing.T) {
+	svc := newFileSvc((context.Background()))
 
+	// create a file with duplicate "/" in the path name
+	testFileCreate(t, svc, "/parigot/app///file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	// create a file with . in the path name
+	testFileCreate(t, svc, "/parigot/app/./file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	// create a file with .. in the path name
+	testFileCreate(t, svc, "/parigot/app/../file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+	// create a file without prefix '/parigot/app/'
+	testFileCreate(t, svc, "file.go", fileContent, "bad path name", true, int32(file.FileErr_InvalidPathError))
+
+	// create a file with a good name
+	fid := creatAGoodFile(t, svc)
+	// create a file already exist
+	fid2 := creatAGoodFile(t, svc)
+	if !fid.Equal(fid2) {
+		t.Errorf("unexpected that the file was not appended")
+	}
+
+	// close a file twice, the seconde time there should have an error
+	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
+	testFileClose(t, svc, fid, "close a file", true, int32(file.FileErr_NotExistError))
+
+	// create a file with the same path
+	fid2 = creatAGoodFile(t, svc)
+	if fid.Equal(fid2) {
+		t.Errorf("unexpected that second creation of a deleted file gives same id")
+	}
 }
 
-func testFileCreate(t *testing.T, svc *fileSvcImpl, path string, msg string, errorExpected bool, expectedCode uint16) file.FileId {
+func testFileCreate(t *testing.T, svc *fileSvcImpl, path string, content string, msg string,
+	expectedErr bool, expectedErrCode int32) file.FileId {
+
 	ctx := pcontext.DevNullContext(context.Background())
 	t.Helper()
 
-	create := &filemsg.CreateRequest{
-		Path: path,
+	openReq := &file.CreateRequest{
+		Path:    path,
+		Content: content,
 	}
-	resp := &filemsg.CreateResponse{}
-	err := file.NewFileErrIdFromRaw(svc.create(ctx, create, resp))
-	if errorExpected {
-		if !err.IsError() {
-			t.Errorf("expected error: %s :%s", msg, err.Short())
+	openResp := &file.CreateResponse{}
+	errCode := svc.create(ctx, openReq, openResp)
+	if expectedErr {
+		if errCode == int32(file.FileErr_NoError) {
+			log.Fatalf("expected error from creating a file: %s :%d", msg, errCode)
 		}
-		if file.FileErrIdCode(expectedCode) != err.ErrorCode() {
-			t.Errorf("wrong code : %s, expected %d but got %d", msg, expectedCode, err.ErrorCode())
+		if expectedErrCode != errCode {
+			log.Fatalf("wrong error code from creating a file: %s, expected %d but got %d",
+				msg, expectedErrCode, errCode)
 		}
-		return file.ZeroValueFileId()
+		return file.FileIdZeroValue()
 	}
 
 	// no error expected case
-	if err.IsError() {
-		t.Errorf("unexpected error: %s :%s", msg, err.Short())
-		return file.ZeroValueFileId()
+	if errCode != int32(file.FileErr_NoError) {
+		log.Fatalf("unexpected error from creating a file: %s :%d", msg, errCode)
 	}
 
-	return file.MustUnmarshalFileId(resp.GetId())
+	return file.UnmarshalFileId(openResp.GetId())
+}
+
+func testFileClose(t *testing.T, svc *fileSvcImpl, fid file.FileId, msg string,
+	expectedErr bool, expectedErrCode int32) {
+
+	ctx := pcontext.DevNullContext(context.Background())
+	t.Helper()
+
+	req := &file.CloseRequest{}
+	resp := &file.CloseResponse{}
+	req.Id = fid.Marshal()
+	errCode := svc.close(ctx, req, resp)
+	if expectedErr {
+		if errCode == int32(file.FileErr_NoError) {
+			log.Fatalf("expected error from closing a file (%s): %s: %d", fid, msg, errCode)
+		}
+		if errCode != expectedErrCode {
+			log.Fatalf("wrong error code from closing a file (%s): %s expected %d but got %d",
+				fid, msg, expectedErrCode, errCode)
+		}
+		return
+	}
+
+	// no error expected case
+	if errCode != int32(file.FileErr_NoError) {
+		log.Fatalf("unexpected error from closing a file (%s): %s :%d", fid, msg, errCode)
+	}
+	candidate := file.UnmarshalFileId(resp.GetId())
+	if !fid.Equal(candidate) {
+		log.Fatalf("created and closed file id don't match")
+	}
+	return
+}
+
+func creatAGoodFile(t *testing.T, svc *fileSvcImpl) file.FileId {
+	return testFileCreate(t, svc, "/parigot/app/file.go", fileContent, "good path name",
+		false, int32(file.FileErr_NoError))
 }

--- a/apiplugin/file/filehost.go
+++ b/apiplugin/file/filehost.go
@@ -5,9 +5,14 @@ import (
 	"unsafe"
 
 	"github.com/iansmith/parigot/apiplugin"
+	"github.com/iansmith/parigot/apishared/id"
+	pcontext "github.com/iansmith/parigot/context"
 	"github.com/iansmith/parigot/eng"
-	"github.com/iansmith/parigot/g/file/v1"
+	file "github.com/iansmith/parigot/g/file/v1"
+	filemsg "github.com/iansmith/parigot/g/msg/file/v1"
 	"github.com/iansmith/parigot/sys"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/tetratelabs/wazero/api"
 )
@@ -16,6 +21,7 @@ import (
 // you'll need to pick the short names and letters for them... I would
 // recommend f for FileId and F for FileErrId, but you can choose
 // others if you want.
+var fileSvc *fileSvcImpl
 
 type filePlugin struct{}
 
@@ -37,27 +43,99 @@ var ParigiotInitialize sys.ParigotInit = &filePlugin{}
 // via CurrentTime()... later on we will be expiring entries
 // in fileDataCache
 
-type myFileInfo struct{}
+type myFileInfo struct {
+	// id
+	// path
+	// status
+	// lastAccessTime
+}
 
 // for now, create a map of FileId -> to myFileInfo
-//var fileDataCache = make(map[Fileid])*myFileInfo
+// var fileDataCache = make(map[Fileid])*myFileInfo
+
+type fileSvcImpl struct {
+	fileDataCache *map[file.FileId]*myFileInfo
+	ctx           context.Context
+}
 
 func (*filePlugin) Init(ctx context.Context, e eng.Engine) bool {
-	e.AddSupportedFunc(ctx, "file", "open_", open) // this should call the "wrapper"
+	e.AddSupportedFunc(ctx, "file", "open_file_", openFileHost) // this should call the "wrapper"
+	e.AddSupportedFunc(ctx, "file", "create_file_", createFileHost)
+	e.AddSupportedFunc(ctx, "file", "close_file_", closeFileHost)
+
+	_ = newFileSvc(ctx)
+
 	return true
 }
 
-// true native implementation of open... assume this is read only
-func openImpl(ctx context.Context, in *file.OpenRequest, out *file.OpenResponse) int32 {
-	// use Os
-	return int32(file.FileErr_NoError)
+func hostBase[T proto.Message, U proto.Message](ctx context.Context, fnName string,
+	fn func(context.Context, T, U) id.IdRaw, m api.Module, stack []uint64, req T, resp U) {
+	defer func() {
+		if r := recover(); r != nil {
+			print(">>>>>>>> Trapped recover in set up for   ", fnName, "<<<<<<<<<<\n")
+		}
+	}()
+	apiplugin.InvokeImplFromStack(ctx, fnName, m, stack, fn, req, resp)
 }
 
-// the wrappers always look like this.. notice where openImpl is in this function
-func open(ctx context.Context, m api.Module, stack []uint64) {
-	req := &file.OpenRequest{}
-	resp := &file.OpenResponse{}
-	apiplugin.InvokeImplFromStack(ctx, "[file]open", m, stack, openImpl, req, resp)
+// // true native implementation of open... assume this is read only
+// func openImpl(ctx context.Context, in *file.OpenRequest, out *file.OpenResponse) int32 {
+// 	// use Os
+// 	return int32(file.FileErr_NoError)
+// }
+
+// // the wrappers always look like this.. notice where openImpl is in this function
+// func open(ctx context.Context, m api.Module, stack []uint64) {
+// 	req := &file.OpenRequest{}
+// 	resp := &file.OpenResponse{}
+// 	apiplugin.InvokeImplFromStack(ctx, "[file]open", m, stack, openImpl, req, resp)
+// }
+
+func openFileHost(ctx context.Context, m api.Module, stack []uint64) {
+	req := &filemsg.OpenRequest{}
+	resp := &filemsg.OpenResponse{}
+
+	hostBase(ctx, "[file]open", fileSvc.open, m, stack, req, resp)
+}
+
+func createFileHost(ctx context.Context, m api.Module, stack []uint64) {
+	req := &filemsg.CreateRequest{}
+	resp := &filemsg.CreateResponse{}
+
+	hostBase(ctx, "[file]create", fileSvc.create, m, stack, req, resp)
+}
+
+func closeFileHost(ctx context.Context, m api.Module, stack []uint64) {
+	req := &filemsg.CloseRequest{}
+	resp := &filemsg.CloseResponse{}
+
+	hostBase(ctx, "[file]close", fileSvc.close, m, stack, req, resp)
+}
+
+func newFileSvc(ctx context.Context) *fileSvcImpl {
+	newCtx := pcontext.ServerGoContext(ctx)
+
+	f := &fileSvcImpl{
+		fileDataCache: &map[file.FileId]*myFileInfo{},
+		ctx:           newCtx,
+	}
+
+	return f
+}
+
+// read only, need to be implemented
+func (f *fileSvcImpl) open(ctx context.Context, req *filemsg.OpenRequest, resp *filemsg.OpenResponse) id.IdRaw {
+	return file.FileErrIdNoErr.Raw()
+}
+
+// write only, need to be implemented
+func (f *fileSvcImpl) create(ctx context.Context, req *filemsg.CreateRequest, resp *filemsg.CreateResponse) id.IdRaw {
+	return file.FileErrIdNoErr.Raw()
+}
+
+// close only, need to be implemented
+func (f *fileSvcImpl) close(ctx context.Context, req *filemsg.CloseRequest, resp *filemsg.CloseResponse) id.IdRaw {
+	return file.FileErrIdNoErr.Raw()
 }
 
 //  add two more functions: create and close.  Create is

--- a/apiplugin/queue/queue_test.go
+++ b/apiplugin/queue/queue_test.go
@@ -270,9 +270,9 @@ func testQueueCreate(t *testing.T, svc *queueSvcImpl, name, msg string, errorExp
 	ctx := pcontext.DevNullContext(context.Background())
 
 	t.Helper()
-	create := &queuemsg.CreateQueueRequest{}
+	create := &queue.CreateQueueRequest{}
 	create.QueueName = name
-	resp := &queuemsg.CreateQueueResponse{}
+	resp := &queue.CreateQueueResponse{}
 	err := queue.NewQueueErrIdFromRaw(svc.create(ctx, create, resp))
 	if errorExpected {
 		if !err.IsError() {
@@ -297,10 +297,10 @@ func setupQueue(t *testing.T, svc *queueSvcImpl) queue.QueueId {
 	t.Helper()
 	ctx := pcontext.DevNullContext(context.Background())
 
-	creat := &queue.CreateQueueRequest{}
-	creat.QueueName = queueNameInTest
+	create := &queue.CreateQueueRequest{}
+	create.QueueName = queueNameInTest
 	resp := &queue.CreateQueueResponse{}
-	err := queue.NewQueueErrIdFromRaw(svc.create(ctx, creat, resp))
+	err := queue.NewQueueErrIdFromRaw(svc.create(ctx, create, resp))
 	if err.IsError() {
 		t.Errorf("expected queue to be created")
 	}

--- a/apiplugin/queue/queue_test.go
+++ b/apiplugin/queue/queue_test.go
@@ -270,10 +270,10 @@ func testQueueCreate(t *testing.T, svc *queueSvcImpl, name, msg string, errorExp
 	ctx := pcontext.DevNullContext(context.Background())
 
 	t.Helper()
-	creat := &queue.CreateQueueRequest{}
-	creat.QueueName = name
-	resp := &queue.CreateQueueResponse{}
-	err := queue.NewQueueErrIdFromRaw(svc.create(ctx, creat, resp))
+	create := &queuemsg.CreateQueueRequest{}
+	create.QueueName = name
+	resp := &queuemsg.CreateQueueResponse{}
+	err := queue.NewQueueErrIdFromRaw(svc.create(ctx, create, resp))
 	if errorExpected {
 		if !err.IsError() {
 			t.Errorf("expected error: %s :%s", msg, err.Short())


### PR DESCRIPTION
It contains 2 main tests: TestOpenClose & TestCreateClose

The current rules are a bit weird...... Files have 2 states: OPEN and CLOSE. Once a file is created, its initial state is CLOSE. When a file is opened, its state will change to OPEN. A file whose status is OPEN cannot be opened or created. A close request will not change the state to CLOSE but will release the file from the file data cache. 
The question is, if we want to change a file to CLOSE, but not release it, what should we do? (May need to make some changes in status)