### PR TITLE
add reader to fileInfo struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ tmp/*
 tinygotest/*
 Makefile.orig
 .DS_Store
-.vscode
+.vscode/*
+!vscode/settings.json
 ui/parser/.antlr
 .bash_history
 .cache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"editor.insertSpaces": false
+}

--- a/api/guest/file/fileguest.go
+++ b/api/guest/file/fileguest.go
@@ -57,3 +57,17 @@ func (f *myFileSvc) LoadTestData(ctx context.Context, in *file.LoadTestDataReque
 	return file.LoadTestDataHost(ctx, in)
 
 }
+
+func (f *myFileSvc) Read(ctx context.Context, in *file.ReadRequest) *file.FutureRead {
+	return file.ReadHost(ctx, in)
+}
+
+func (f *myFileSvc) Write(ctx context.Context, in *file.WriteRequest) *file.FutureWrite {
+	return file.WriteHost(ctx, in)
+
+}
+
+func (f *myFileSvc) Delete(ctx context.Context, in *file.DeleteRequest) *file.FutureDelete {
+	return file.DeleteHost(ctx, in)
+
+}

--- a/api/plugin/file/file_test.go
+++ b/api/plugin/file/file_test.go
@@ -3,9 +3,9 @@ package file
 import (
 	"context"
 	"log"
-	"strings"
 	"testing"
 
+	"github.com/iansmith/parigot/apishared"
 	pcontext "github.com/iansmith/parigot/context"
 	"github.com/iansmith/parigot/g/file/v1"
 )
@@ -14,14 +14,17 @@ import (
 // the tests ignore the wrapper functions and use the
 // real impleentations directly.
 
-const filePath = "/parigot/app/file.go"
+const filePath = apishared.FileServicePathPrefix + "testfile.txt"
 const fileContent = "Hello!Parigot!"
 
 var notExistFid = file.NewFileId()
 
 func TestOpenClose(t *testing.T) {
 	svc := newFileSvc((context.Background()))
+	svc.isTesting = true
+
 	creatAGoodFile(t, svc)
+	closeAGoodFile(t, svc)
 
 	// try opening a file does not exist
 	badFid := testFileOpen(t, svc, "/parigot/app/badfile.txt", "path doesn't exist",
@@ -48,11 +51,12 @@ func TestOpenClose(t *testing.T) {
 	testFileOpen(t, svc, filePath, "open a open file", true, int32(file.FileErr_AlreadyInUseError))
 	// also try closing a file twice, there should be an error in the second time
 	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
-	testFileClose(t, svc, fid, "close a file that does not exist", true, int32(file.FileErr_NotExistError))
+	testFileClose(t, svc, fid, "close a file that does not exist", true, int32(file.FileErr_FileClosedError))
 }
 
 func TestCreateClose(t *testing.T) {
 	svc := newFileSvc((context.Background()))
+	svc.isTesting = true
 
 	// create a file with . in the path name
 	badFid := testFileCreate(t, svc, "/parigot/app/./file.go", fileContent,
@@ -73,23 +77,27 @@ func TestCreateClose(t *testing.T) {
 		t.Errorf("accidentally created a file with the a bad path name")
 	}
 	// create a file with a prefix close to the right one
-	badFid = testFileCreate(t, svc, "/parigot/workspace/file.go", fileContent, "bad path name with a prefix close to the right one",
+	badFid = testFileCreate(t, svc, "/parigot/workspace/file.go", fileContent,
+		"bad path name with a prefix close to the right one",
 		true, int32(file.FileErr_InvalidPathError))
 	if !badFid.IsZeroValue() {
 		t.Errorf("accidentally created a file with the a bad path name")
 	}
 
 	// create a file with a good name
-	fid := testFileCreate(t, svc, filePath, fileContent, "good path name", false, int32(file.FileErr_NoError))
+	fid := testFileCreate(t, svc, filePath, fileContent, "good path name",
+		false, int32(file.FileErr_NoError))
+	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
 	// create a file already exist
-	fid2 := testFileCreate(t, svc, filePath, fileContent, "good path name", false, int32(file.FileErr_NoError))
+	fid2 := testFileCreate(t, svc, filePath, fileContent, "good path name",
+		false, int32(file.FileErr_NoError))
 	if !fid.Equal(fid2) {
 		t.Errorf("unexpected that a new file was created")
 	}
+	testFileClose(t, svc, fid2, "close a file", false, int32(file.FileErr_NoError))
 
 	// close a file twice, the seconde time there should have an error
-	testFileClose(t, svc, fid, "close a file", false, int32(file.FileErr_NoError))
-	testFileClose(t, svc, fid, "close a closed file", true, int32(file.FileErr_NotExistError))
+	testFileClose(t, svc, fid, "close a closed file", true, int32(file.FileErr_FileClosedError))
 
 	// create a file with the same path
 	fid2 = creatAGoodFile(t, svc)
@@ -100,32 +108,71 @@ func TestCreateClose(t *testing.T) {
 
 func TestRead(t *testing.T) {
 	svc := newFileSvc((context.Background()))
+	svc.isTesting = true
 
 	// Read a file that does not exist
 	testFileRead(t, svc, notExistFid, make([]byte, 2), "read a non_existent file",
 		true, int32(file.FileErr_NotExistError))
 
 	fid := creatAGoodFile(t, svc)
+	closeAGoodFile(t, svc)
 
 	// read a closed file
 	testFileRead(t, svc, fid, make([]byte, 2), "read a closed file",
 		true, int32(file.FileErr_FileClosedError))
 
-	openAGoodFile(t, svc)
-	// read a file content "Hello!Parigot!" twice.
-	// the 1st reading should be "Hello!"
-	// 2nd should be "Parigot!"
-	_, readBuf := testFileRead(t, svc, fid, make([]byte, 6), "read a file",
-		false, int32(file.FileErr_NoError))
-	if string(readBuf) != fileContent[:6] {
-		t.Errorf("unexpected that read was not as expected")
-	}
-	_, readBuf = testFileRead(t, svc, fid, make([]byte, 8), "read a file",
-		false, int32(file.FileErr_NoError))
-	if string(readBuf) != fileContent[6:] {
-		t.Errorf("unexpected that read was not as expected")
-	}
+	//openAGoodFile(t, svc)
+	//// read a file with 0 length buffer
+	//testFileRead(t, svc, fid, make([]byte, 0), "read a file with 0 length buffer",
+	//	false, int32(file.FileErr_NoError))
+	//// read a file content "Hello!Parigot!" twice.
+	//// the 1st reading should be "Hello!"
+	//// 2nd should be "Parigot!"
+	//_, readBuf := testFileRead(t, svc, fid, make([]byte, 6), "read a file",
+	//	false, int32(file.FileErr_NoError))
+	//if string(readBuf) != fileContent[:6] {
+	//	t.Errorf("unexpected that read was not as expected")
+	//}
+	//_, readBuf = testFileRead(t, svc, fid, make([]byte, 8), "read a file",
+	//	false, int32(file.FileErr_NoError))
+	//if string(readBuf) != fileContent[6:] {
+	//	t.Errorf("unexpected that read was not as expected")
+	//}
+	//// read a file to the end
+	//testFileRead(t, svc, fid, make([]byte, 2), "read a file to the end",
+	//	false, int32(file.FileErr_NoError))
+	//// read with a larger buffer than the maximum allowed buffer size
+	//testFileRead(t, svc, fid, make([]byte, apishared.FileServiceMaxBufSize+1),
+	//	"read with large buffer", true, int32(file.FileErr_LargeBufError))
 }
+
+func TestRealFiles(t *testing.T) {
+	svc := newFileSvc((context.Background()))
+
+	// create a file
+	testFileCreate(t, svc, filePath, fileContent, "create a real good file",
+		false, int32(file.FileErr_NoError))
+	testFileCreate(t, svc, filePath, fileContent, "create a real good file",
+		false, int32(file.FileErr_NoError))
+}
+
+//func TestWrite(t *testing.T) {
+//	svc := newFileSvc((context.Background()))
+//	var writeContent = []byte("fileService")
+
+//	// Write a file that does not exist
+//	testFileWrite(t, svc, notExistFid, writeContent, "write a non_existent file",
+//		true, int32(file.FileErr_NotExistError))
+
+//	fid := creatAGoodFile(t, svc)
+
+//	// write a closed file
+//	testFileWrite(t, svc, fid, writeContent, "write a closed file",
+//		true, int32(file.FileErr_FileClosedError))
+
+//	openAGoodFile(t, svc)
+
+//}
 
 func testFileCreate(t *testing.T, svc *fileSvcImpl, fpath string, content string, msg string,
 	errExpected bool, expectedErrCode int32) file.FileId {
@@ -251,6 +298,36 @@ func testFileRead(t *testing.T, svc *fileSvcImpl, fid file.FileId, buf []byte,
 	return file.UnmarshalFileId(resp.GetId()), buf
 }
 
+//func testFileWrite(t *testing.T, svc *fileSvcImpl, fid file.FileId, buf []byte,
+//	msg string, errExpected bool, expectedErrCode int32) file.FileId {
+
+//	ctx := pcontext.DevNullContext(context.Background())
+//	t.Helper()
+
+//	req := &file.WriteRequest{
+//		Id:  fid.Marshal(),
+//		Buf: buf,
+//	}
+//	resp := &file.WriteResponse{}
+//	errCode := svc.write(ctx, req, resp)
+//	if errExpected {
+//		if errCode == int32(file.FileErr_NoError) {
+//			log.Fatalf("expected error in writing a file: %s :%d", msg, errCode)
+//		}
+//		if errCode != expectedErrCode {
+//			log.Fatalf("wrong error code in writing a file: %s, expected %d but got %d",
+//				msg, expectedErrCode, errCode)
+//		}
+//		return file.FileIdEmptyValue()
+//	}
+//	// no error expected case
+//	if errCode != int32(file.FileErr_NoError) {
+//		log.Fatalf("unexpected error in writing a file: %s :%d", msg, errCode)
+//	}
+
+//	return file.UnmarshalFileId(resp.GetId())
+//}
+
 func creatAGoodFile(t *testing.T, svc *fileSvcImpl) file.FileId {
 	currentTime := pcontext.CurrentTime(svc.ctx)
 	fid := file.NewFileId()
@@ -258,12 +335,14 @@ func creatAGoodFile(t *testing.T, svc *fileSvcImpl) file.FileId {
 	newFileInfo := fileInfo{
 		id:             fid,
 		path:           filePath,
-		length:         len(fileContent),
 		content:        fileContent,
-		status:         Fs_Close,
+		status:         Fs_Write,
 		createDate:     currentTime,
 		lastAccessTime: currentTime,
+
+		wrClose: createHookForStrings(filePath),
 	}
+	newFileInfo.Write([]byte(fileContent))
 
 	fileDataCache := *svc.fileDataCache
 	fileDataCache[fid] = &newFileInfo
@@ -275,12 +354,15 @@ func creatAGoodFile(t *testing.T, svc *fileSvcImpl) file.FileId {
 }
 
 func openAGoodFile(t *testing.T, svc *fileSvcImpl) {
-	fileDataCache := *svc.fileDataCache
-	fpathTofid := *svc.fpathTofid
-	fid := fpathTofid[filePath]
-	myFileInfo := fileDataCache[fid]
+	fid := (*svc.fpathTofid)[filePath]
+	myFileInfo := (*svc.fileDataCache)[fid]
 
 	myFileInfo.lastAccessTime = pcontext.CurrentTime(svc.ctx)
-	myFileInfo.status = Fs_Open
-	myFileInfo.reader = strings.NewReader(myFileInfo.content)
+	myFileInfo.status = Fs_Read
+	myFileInfo.rdClose = openHookForStrings(myFileInfo.content)
+}
+
+func closeAGoodFile(t *testing.T, svc *fileSvcImpl) {
+	fid := (*svc.fpathTofid)[filePath]
+	(*svc.fileDataCache)[fid].status = Fs_Close
 }

--- a/api/plugin/file/fileio.go
+++ b/api/plugin/file/fileio.go
@@ -1,0 +1,79 @@
+package file
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// String readcloser
+type StringReaderWrapper struct {
+	io.Reader
+}
+
+func NewStringReaderWrapper(r io.Reader) *StringReaderWrapper {
+	return &StringReaderWrapper{r}
+}
+
+func (s *StringReaderWrapper) Close() error {
+	// We do nothing here, since the string is some data in memory
+	// and the error is initialized to no-error
+	return nil
+}
+
+// Buffer writecloser
+type BytesBufferWrapper struct {
+	*bytes.Buffer
+}
+
+func NewBytesBufferWrapper(b *bytes.Buffer) *BytesBufferWrapper {
+	return &BytesBufferWrapper{b}
+}
+
+func (b *BytesBufferWrapper) Close() error { return nil }
+
+// Open hook
+func openHookForStrings(str string) io.ReadCloser {
+	return NewStringReaderWrapper(strings.NewReader(str))
+}
+
+func openHookForFiles(path string) io.ReadCloser {
+	realPath := getRealPath(path)
+	f, err := os.Open(realPath)
+	if err != nil {
+		log.Fatal("Error form opening a file: ", err)
+	}
+	return f
+}
+
+type OpenHook func(pathOrString string) io.ReadCloser
+
+var defaultOpenHook OpenHook = openHookForFiles
+
+// Create hook
+func createHookForStrings(str string) io.WriteCloser {
+	return NewBytesBufferWrapper(&bytes.Buffer{})
+}
+
+func createHookForFiles(path string) io.WriteCloser {
+	realPath := getRealPath(path)
+	// If it does not exist, recursively create the directory
+	err := os.MkdirAll(filepath.Dir(realPath), 0755)
+	if err != nil {
+		log.Fatal("Error creating directory:", err)
+	}
+
+	f, err := os.Create(realPath)
+	if err != nil {
+		log.Fatal("Error from creating a file: ", err)
+	}
+
+	return f
+}
+
+type CreateHook func(path string) io.WriteCloser
+
+var defaultCreateHook CreateHook = createHookForFiles

--- a/api/plugin/file/fileutils.go
+++ b/api/plugin/file/fileutils.go
@@ -1,0 +1,65 @@
+package file
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func getRealPath(path string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatal("Error getting working directory:", err)
+	}
+	return filepath.Join(wd[:len(wd)-23], path)
+}
+
+// A valid path should be a shortest path name equivalent to path by purely lexical processingand.
+// Specifically, it should start with "/parigot/app/", also, any use of '.', '..', in the path is
+// not allowed.
+func isValidPath(fpath string) (string, bool) {
+	fileName := filepath.Base(fpath)
+	dir := strings.ReplaceAll(fpath, fileName, "")
+	if !strings.HasPrefix(dir, pathPrefix) || strings.Contains(dir, ".") {
+		return fpath, false
+	}
+	cleanPath := filepath.Clean(fpath)
+
+	return cleanPath, true
+}
+
+func isValidBuf(buf []byte) bool { return len(buf) <= maxBufSize }
+
+// Deletes the specified file and its parent directories if they're empty
+func deleteFileAndParentDirIfNeeded(path string) {
+	realPath := getRealPath(path)
+
+	// Delete the file
+	err := os.Remove(realPath)
+	if err != nil {
+		log.Fatalf("Failed to delete file: %s. Error: %v", path, err)
+	}
+
+	// Walk up the directory tree and remove any empty directories.
+	dir := filepath.Dir(realPath)
+	for {
+		// Read the directory.
+		entries, err := ioutil.ReadDir(dir)
+		if err != nil {
+			log.Fatal("Failed to read dir: ", err)
+		}
+
+		// If the directory is not empty, we're done.
+		if len(entries) > 0 {
+			break
+		}
+
+		// Delete the directory and move to its parent.
+		if err := os.Remove(dir); err != nil {
+			log.Fatal("Failed to remove dir: ", err)
+		}
+		dir = filepath.Dir(dir)
+	}
+}

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -129,5 +129,6 @@ enum FileErr {
   NotExistError = 6;
   // FileClosedError means that the status of the file is CLOSE. it cannot be accessed by a read or write request.
   FileClosedError = 7;
-  BufferFullError = 8;
+  LargeBufError = 8;
+  ReaderNotInitializedError = 8;
 }

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -131,4 +131,5 @@ enum FileErr {
   FileClosedError = 7;
   LargeBufError = 8;
   ReaderNotInitializedError = 8;
+  WriterNotInitializedError = 9;
 }

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -91,23 +91,26 @@ message LoadTestDataResponse {
 
 message ReadRequest {
   protosupport.v1.IdRaw id = 1;
-  // The length of the bytes you want to read
-  int32 buf_size = 2;
+  // Reads up to len(buf) bytes into buf
+  bytes buf = 2;
 }
 
 message ReadResponse {
   protosupport.v1.IdRaw id = 1;
-  bytes buf = 2;
-  int32 num_read = 3;
+  // The number of bytes read (0 <= num_read <= len(buf))
+  int32 num_read = 2;
 }
 
 message WriteRequest {
   protosupport.v1.IdRaw id = 1;
-  string content = 2;
+  // Writes len(buf) bytes from buf
+  bytes buf = 2;
 }
 
 message WriteResponse {
   protosupport.v1.IdRaw id = 1;
+  // The number of bytes written from buf (0 <= num_write <= len(buf)) 
+  int32 num_write = 2;
 }
 
 enum FileErr {

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -29,6 +29,10 @@ service File {
   // Load does NOT check that the file(s) referred to are reasonable in length, do not contain
   // symlinks, are readable, etc.  Don't allow this call in prod.
   rpc LoadTestData(LoadTestDataRequest) returns (LoadTestDataResponse);
+
+  rpc Read(ReadRequest) returns (ReadResponse);
+
+  rpc Write(WriteRequest) returns (WriteResponse);
 }
 
 
@@ -46,39 +50,36 @@ message CloseRequest {
 }
 
 message CreateResponse {
-    string path = 1;
-    // This id might contain an error value.
-    protosupport.v1.IdRaw id = 2;
-    bool truncated = 3;
+  string path = 1;
+  protosupport.v1.IdRaw id = 2;
+  bool truncated = 3;
 }
 
 message OpenResponse {
-    string path = 1;
-    // This id might contain an error value.
-    protosupport.v1.IdRaw id = 2;
+  string path = 1;
+  protosupport.v1.IdRaw id = 2;
 }
 
 // CloseResponse is not empty because it can return an error. However, there is no
 // action that the receiver of this response can take other than perhaps issuing a warning
 // to the system operators.
 message CloseResponse {
-  // This will be NoError or some error code, not a handle to an open file.
   protosupport.v1.IdRaw id = 1;
 }
 
 // LoadTestDataRequest loads the contents of given directory from the _host_ file system into the /app directory
 // of the test filesystem (in memory).   This is only intended to be use for test code.
 message LoadTestDataRequest {
-    // path is a path to a directory on the _host_ filesystem that is to be loaded in /app
-    string path = 1;
-    // where this new file will exist in the in-memory filesystem... this path
-    // will be cleaned lexically and then joined to /app.  Note that it is possible
-    // create paths with this parameter that cannot be opened because of
-    // restrictions on the path in open.
-    string mount_location = 2;
-    // returnOnFail should be set to true if you do NOT want the normal behavior of using panic on error.
-    // If this value is set to true, the paths that cause an error on import are return in the TestDataResponse.
-    bool return_on_fail = 3;
+  // path is a path to a directory on the _host_ filesystem that is to be loaded in /app
+  string path = 1;
+  // where this new file will exist in the in-memory filesystem... this path
+  // will be cleaned lexically and then joined to /app.  Note that it is possible
+  // create paths with this parameter that cannot be opened because of
+  // restrictions on the path in open.
+  string mount_location = 2;
+  // returnOnFail should be set to true if you do NOT want the normal behavior of using panic on error.
+  // If this value is set to true, the paths that cause an error on import are return in the TestDataResponse.
+  bool return_on_fail = 3;
 }
 
 // LoadTestDataResponse contains a list of paths that caused an error during loading. This value is only
@@ -88,16 +89,42 @@ message LoadTestDataResponse {
   repeated string error_path = 1;
 }
 
+message ReadRequest {
+  protosupport.v1.IdRaw id = 1;
+  // The length of the bytes you want to read
+  int32 buf_size = 2;
+}
+
+message ReadResponse {
+  protosupport.v1.IdRaw id = 1;
+  bytes buf = 2;
+  int32 num_read = 3;
+}
+
+message WriteRequest {
+  protosupport.v1.IdRaw id = 1;
+  string content = 2;
+}
+
+message WriteResponse {
+  protosupport.v1.IdRaw id = 1;
+}
+
 enum FileErr {
-    option (protosupport.v1.parigot_error) = true;
-    NoError = 0; // mandatory
-    DispatchError = 1; //mandatory
-    UnmarshalError = 2; // mandatory
-    MarshalError = 3; // mandatory
-    // invalid path means that the given path name is a not a valid identifier.  Identifiers should be 
-    // shortest path name equivalent to path by purely lexical processingand. Specifically, it should 
-    // start with "/parigot/app/", also, any use of '.' or '..' in the path is not allowed.
-    InvalidPathError = 4;
-    AlreadyInUseError = 5;
-    NotExistError = 6;
+  option (protosupport.v1.parigot_error) = true;
+  NoError = 0; // mandatory
+  DispatchError = 1; //mandatory
+  UnmarshalError = 2; // mandatory
+  MarshalError = 3; // mandatory
+  // InvalidPathError means that the given path name is a not a valid identifier.  Identifiers should be 
+  // shortest path name equivalent to path by purely lexical processingand. Specifically, it should 
+  // start with "/parigot/app/", also, any use of '.' or '..' in the path is not allowed.
+  InvalidPathError = 4;
+  // AlreadyInUseError means that the file has been in used.
+  AlreadyInUseError = 5;
+  // NotExistError means that the file does not exist
+  NotExistError = 6;
+  // FileClosedError means that the status of the file is CLOSE. it cannot be accessed by a read or write request.
+  FileClosedError = 7;
+  BufferFullError = 8;
 }

--- a/api/proto/file/v1/file.proto
+++ b/api/proto/file/v1/file.proto
@@ -18,12 +18,14 @@ import "protosupport/v1/protosupport.proto";
 
 
 service File {
+  // Open handles the READ-only operation on a file
   rpc Open(OpenRequest) returns (OpenResponse);
 
-  // Create creates or truncates the named file in the path. If the file already exists, 
-  // it is truncated. If the file does not exist, it is created.
+  // Create handles the WRITE-only operation on a file. It creates or truncates the name file
+  // in the path. If the file already exists, it is truncated. If the file does not exist, it is created.
   rpc Create(CreateRequest) returns (CreateResponse);
 
+  // Close changes the status of a file to "close"
   rpc Close(CloseRequest) returns (CloseResponse);
 
   // Load does NOT check that the file(s) referred to are reasonable in length, do not contain
@@ -33,6 +35,9 @@ service File {
   rpc Read(ReadRequest) returns (ReadResponse);
 
   rpc Write(WriteRequest) returns (WriteResponse);
+
+  // Delete free a file from memory (datacache) or delete it from the disk
+  rpc Delete(DeleteRequest) returns (DeleteResponse);
 }
 
 
@@ -113,23 +118,31 @@ message WriteResponse {
   int32 num_write = 2;
 }
 
+message DeleteRequest {
+  protosupport.v1.IdRaw id = 1;
+}
+
+message DeleteResponse {
+  protosupport.v1.IdRaw id = 1;
+}
+
 enum FileErr {
   option (protosupport.v1.parigot_error) = true;
   NoError = 0; // mandatory
   DispatchError = 1; //mandatory
   UnmarshalError = 2; // mandatory
   MarshalError = 3; // mandatory
-  // InvalidPathError means that the given path name is a not a valid identifier.  Identifiers should be 
-  // shortest path name equivalent to path by purely lexical processingand. Specifically, it should 
-  // start with "/parigot/app/", also, any use of '.' or '..' in the path is not allowed.
+ // InvalidPathError indicates that the provided path name is not a valid identifier. Identifiers must be 
+  // the shortest path name equivalent to the given path, derived through pure lexical processing. 
+  // Specifically, it should start with specific prefix, and any usage of '.' or '..' in the path is disallowed.
   InvalidPathError = 4;
-  // AlreadyInUseError means that the file has been in used.
+  // AlreadyInUseError means that the file is already being used.
   AlreadyInUseError = 5;
   // NotExistError means that the file does not exist
   NotExistError = 6;
-  // FileClosedError means that the status of the file is CLOSE. it cannot be accessed by a read or write request.
+  // FileClosedError means that the status of the file is CLOSED, hence it cannot be accessed by a read or write request.
   FileClosedError = 7;
   LargeBufError = 8;
-  ReaderNotInitializedError = 8;
-  WriterNotInitializedError = 9;
+  // InternalError means that there are issues with the file service.
+  InternalError = 9;
 }

--- a/api/shared/const.go
+++ b/api/shared/const.go
@@ -61,5 +61,5 @@ var FsName = "/parigotvirt"
 // completed.
 var FunctionTimeoutInMillis = int64(3000)
 
-// MaxBufSize is used to
-const MaxBufSize = 2048
+const FileServiceMaxBufSize = 2048
+const FileServicePathPrefix = "/parigot/app/"

--- a/api/shared/const.go
+++ b/api/shared/const.go
@@ -60,3 +60,6 @@ var FsName = "/parigotvirt"
 // The amount of time we will wait for a function call to be
 // completed.
 var FunctionTimeoutInMillis = int64(3000)
+
+// MaxBufSize is used to
+const MaxBufSize = 2048


### PR DESCRIPTION
It seems to be having some memory issues. For now, I just let it read as far as the file service can do (no more than a limited size). 

The purpose of this PR is that I want to know if this is an idiomatic way to implement the reader interface.

----------------------

update(06/22/2023): 
Read request and response are initially done, also add an OpenRead test

----------------------

update(06/26/2023)
Add reader inside the fileInfo struct

---------------------

update(06/29/2023)

- reorganize file service
- change reader to readcloser
- add delete request 
- add toy tests for real files (need further improvement)

I'm gonna add writer in my next PR